### PR TITLE
Fix null handling when retrieving posts

### DIFF
--- a/MiniBBS/Controllers/PostController.cs
+++ b/MiniBBS/Controllers/PostController.cs
@@ -23,6 +23,11 @@ namespace MiniBBS.Controllers
         public async Task<IActionResult> Details(int postId)
         {
             var post = await _postService.GetPostByIdAsync(postId);
+            if (post == null)
+            {
+                return NotFound();
+            }
+
             var comments = await _commentService.GetCommentsByPostIdAsync(postId);
 
             var postDetailsViewModel = new PostDetailsViewModel

--- a/MiniBBS/Service/IServices.cs
+++ b/MiniBBS/Service/IServices.cs
@@ -25,7 +25,7 @@ namespace MiniBBS.Service
     public interface IPostService
     {
         Task<IEnumerable<Post>> GetPostsByForumIdAsync(int forumId);
-        Task<Post> GetPostByIdAsync(int postId);
+        Task<Post?> GetPostByIdAsync(int postId);
         Task<Post> CreatePostAsync(Post post);
         Task UpdatePostAsync(Post post);
         Task DeletePostAsync(int postId);

--- a/MiniBBS/Service/PostService.cs
+++ b/MiniBBS/Service/PostService.cs
@@ -17,9 +17,12 @@ namespace MiniBBS.Service
             return await _dbContext.Posts.Include(x => x.User).Include(x => x.Comments).Where(p => p.ForumID == forumId).ToListAsync();
         }
 
-        public async Task<Post> GetPostByIdAsync(int postId)
+        public async Task<Post?> GetPostByIdAsync(int postId)
         {
-            return await _dbContext.Posts.Include(x => x.User).Include(x => x.Comments).FirstAsync(x => x.PostID == postId);
+            return await _dbContext.Posts
+                .Include(x => x.User)
+                .Include(x => x.Comments)
+                .FirstOrDefaultAsync(x => x.PostID == postId);
         }
 
         public async Task<Post> CreatePostAsync(Post post)


### PR DESCRIPTION
## Summary
- safely fetch posts by ID using `FirstOrDefaultAsync`
- allow null return from `IPostService.GetPostByIdAsync`
- check for `null` in `PostController.Details`

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431faeeee48327ad1ef26ff6d4d2af