### PR TITLE
Improve test coverage with UI integration tests

### DIFF
--- a/MiniBBS.Tests/CommentServiceTests.cs
+++ b/MiniBBS.Tests/CommentServiceTests.cs
@@ -35,4 +35,24 @@ public class CommentServiceTests
         var fetched = await service.GetCommentByIdAsync(comment.CommentID);
         Assert.Equal("cc", fetched.Content);
     }
+
+    [Fact]
+    public async Task CanUpdateAndDeleteComment()
+    {
+        using var context = GetContext();
+        context.Forums.Add(new Forum { ForumID = 1, ForumName = "f", Description = "" });
+        context.Users.Add(new User { Id = 1, UserName = "u" });
+        context.Posts.Add(new Post { PostID = 1, Title = "t", Content = "c", ForumID = 1, UserID = 1 });
+        context.Comments.Add(new Comment { CommentID = 1, Content = "cc", PostID = 1, UserID = 1, PostedTime = DateTime.UtcNow });
+        await context.SaveChangesAsync();
+
+        var service = new CommentService(context);
+        var comment = await service.GetCommentByIdAsync(1);
+        comment!.Content = "new";
+        await service.UpdateCommentAsync(comment);
+        Assert.Equal("new", (await service.GetCommentByIdAsync(1))!.Content);
+
+        await service.DeleteCommentAsync(1);
+        Assert.Empty(await service.GetCommentsByPostIdAsync(1));
+    }
 }

--- a/MiniBBS.Tests/ForumServiceTests.cs
+++ b/MiniBBS.Tests/ForumServiceTests.cs
@@ -25,4 +25,18 @@ public class ForumServiceTests
         Assert.NotNull(fetched);
         Assert.Equal("Test", fetched.ForumName);
     }
+
+    [Fact]
+    public async Task CanUpdateAndDeleteForum()
+    {
+        using var context = GetContext();
+        var service = new ForumService(context);
+        var forum = await service.CreateForumAsync(new Forum { ForumName = "Old", Description = "d" });
+        var updated = await service.UpdateForumAsync(forum.ForumID, new Forum { ForumName = "New", Description = "d2" });
+        Assert.Equal("New", updated?.ForumName);
+
+        var result = await service.DeleteForumAsync(forum.ForumID);
+        Assert.True(result);
+        Assert.Empty(await service.GetAllForumsAsync());
+    }
 }

--- a/MiniBBS.Tests/HomeControllerTests.cs
+++ b/MiniBBS.Tests/HomeControllerTests.cs
@@ -1,0 +1,68 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MiniBBS.Controllers;
+using MiniBBS.DB;
+using MiniBBS.Models;
+using MiniBBS.Service;
+using Moq;
+using System.Security.Claims;
+using System.Collections.Generic;
+
+namespace MiniBBS.Tests;
+
+public class HomeControllerTests
+{
+    private static UserManager<User> CreateUserManager()
+    {
+        var store = new Mock<IUserStore<User>>();
+        var options = new Mock<IOptions<IdentityOptions>>();
+        options.Setup(o => o.Value).Returns(new IdentityOptions());
+        return new UserManager<User>(store.Object, options.Object, new PasswordHasher<User>(), [], [], new UpperInvariantLookupNormalizer(), new IdentityErrorDescriber(), null!, new Mock<ILogger<UserManager<User>>>().Object);
+    }
+
+    private static SignInManager<User> CreateSignInManager(bool signedIn)
+    {
+        var userManager = CreateUserManager();
+        var contextAccessor = new Mock<IHttpContextAccessor>();
+        var claimsFactory = new Mock<IUserClaimsPrincipalFactory<User>>();
+        var options = new Mock<IOptions<IdentityOptions>>();
+        options.Setup(o => o.Value).Returns(new IdentityOptions());
+        var logger = new Mock<ILogger<SignInManager<User>>>();
+        var schemes = new Mock<IAuthenticationSchemeProvider>();
+        var confirmation = new Mock<IUserConfirmation<User>>();
+
+        var managerMock = new Mock<SignInManager<User>>(userManager, contextAccessor.Object, claimsFactory.Object,
+            options.Object, logger.Object, schemes.Object, confirmation.Object);
+        managerMock.Setup(m => m.IsSignedIn(It.IsAny<ClaimsPrincipal>())).Returns(signedIn);
+        return managerMock.Object;
+    }
+
+    [Fact]
+    public async Task Index_ReturnsViewWithModel()
+    {
+        var forums = new List<Forum> { new() { ForumID = 1, ForumName = "f" } };
+        var posts = new List<Post> { new() { PostID = 1, Title = "t", PostedTime = DateTime.UtcNow, User = new User { UserName = "u" }, Comments = new List<Comment>() } };
+
+        var forumService = new Mock<IForumService>();
+        forumService.Setup(f => f.GetAllForumsAsync()).ReturnsAsync(forums);
+        forumService.Setup(f => f.GetForumByIdAsync(1)).ReturnsAsync(forums[0]);
+
+        var postService = new Mock<IPostService>();
+        postService.Setup(p => p.GetPostsByForumIdAsync(1)).ReturnsAsync(posts);
+
+        var controller = new HomeController(forumService.Object, postService.Object, CreateSignInManager(false));
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+
+        var result = await controller.Index(1) as ViewResult;
+        var model = Assert.IsType<IndexViewModel>(result?.Model);
+
+        Assert.Single(model.Forums);
+        Assert.Equal("f", model.SelectedForum.ForumName);
+        var post = Assert.Single(model.Posts);
+        Assert.Equal("t", post.Title);
+    }
+}

--- a/MiniBBS.Tests/MiniBBS.Tests.csproj
+++ b/MiniBBS.Tests/MiniBBS.Tests.csproj
@@ -20,6 +20,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="AngleSharp" Version="1.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MiniBBS.Tests/PostControllerTests.cs
+++ b/MiniBBS.Tests/PostControllerTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Mvc;
+using MiniBBS.Controllers;
+using MiniBBS.DB;
+using MiniBBS.Models;
+using MiniBBS.Service;
+using Moq;
+
+namespace MiniBBS.Tests;
+
+public class PostControllerTests
+{
+    [Fact]
+    public async Task Details_ReturnsViewModel()
+    {
+        var post = new Post { PostID = 1, Title = "t", Content = "c", PostedTime = DateTime.UtcNow, User = new User { UserName = "u" } };
+        var comments = new List<Comment> { new() { CommentID = 1, Content = "cc", PostedTime = DateTime.UtcNow, User = new User { UserName = "u" } } };
+
+        var postService = new Mock<IPostService>();
+        postService.Setup(p => p.GetPostByIdAsync(1)).ReturnsAsync(post);
+        var commentService = new Mock<ICommentService>();
+        commentService.Setup(c => c.GetCommentsByPostIdAsync(1)).ReturnsAsync(comments);
+        var forumService = new Mock<IForumService>();
+
+        var controller = new PostController(postService.Object, commentService.Object, forumService.Object);
+        var result = await controller.Details(1) as ViewResult;
+        var model = Assert.IsType<PostDetailsViewModel>(result?.Model);
+
+        Assert.Equal("t", model.Title);
+        Assert.Single(model.Comments);
+    }
+}

--- a/MiniBBS.Tests/PostServiceTests.cs
+++ b/MiniBBS.Tests/PostServiceTests.cs
@@ -35,4 +35,23 @@ public class PostServiceTests
         var fetched = await service.GetPostByIdAsync(post.PostID);
         Assert.Equal("t", fetched.Title);
     }
+
+    [Fact]
+    public async Task CanUpdateAndDeletePost()
+    {
+        using var context = GetContext();
+        context.Forums.Add(new Forum { ForumID = 1, ForumName = "Test", Description = "" });
+        context.Users.Add(new User { Id = 1, UserName = "u" });
+        var post = new Post { Title = "t", Content = "c", ForumID = 1, UserID = 1, PostedTime = DateTime.UtcNow };
+        context.Posts.Add(post);
+        await context.SaveChangesAsync();
+
+        var service = new PostService(context);
+        post.Title = "new";
+        await service.UpdatePostAsync(post);
+        Assert.Equal("new", (await service.GetPostByIdAsync(post.PostID)).Title);
+
+        await service.DeletePostAsync(post.PostID);
+        Assert.Empty(await service.GetPostsByForumIdAsync(1));
+    }
 }

--- a/MiniBBS.Tests/TestWebApplicationFactory.cs
+++ b/MiniBBS.Tests/TestWebApplicationFactory.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using MiniBBS.DB;
+
+namespace MiniBBS.Tests;
+
+public class TestWebApplicationFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            var descriptor = services.Single(d => d.ServiceType == typeof(DbContextOptions<ForumDbContext>));
+            services.Remove(descriptor);
+            services.AddDbContext<ForumDbContext>(o => o.UseInMemoryDatabase("UITest"));
+
+            var sp = services.BuildServiceProvider();
+            using var scope = sp.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<ForumDbContext>();
+            var userManager = scope.ServiceProvider.GetRequiredService<UserManager<User>>();
+            var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole<int>>>();
+            DbInitializer.InitializeAsync(context, userManager, roleManager).GetAwaiter().GetResult();
+        });
+    }
+}

--- a/MiniBBS.Tests/UiTests.cs
+++ b/MiniBBS.Tests/UiTests.cs
@@ -1,0 +1,35 @@
+using AngleSharp;
+using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+
+namespace MiniBBS.Tests;
+
+public class UiTests
+{
+    private readonly HttpClient _client;
+    private readonly IBrowsingContext _context;
+
+    public UiTests()
+    {
+        var factory = new TestWebApplicationFactory();
+        _client = factory.CreateClient();
+        _context = BrowsingContext.New(Configuration.Default);
+    }
+
+    [Fact]
+    public async Task HomePage_NavigateToPostDetails()
+    {
+        var response = await _client.GetAsync("/");
+        response.EnsureSuccessStatusCode();
+        var html = await response.Content.ReadAsStringAsync();
+        var document = await _context.OpenAsync(req => req.Content(html));
+        var link = document.QuerySelector("tbody tr td a") as IHtmlAnchorElement;
+        Assert.NotNull(link);
+
+        var detail = await _client.GetAsync(link!.Href);
+        detail.EnsureSuccessStatusCode();
+        var detailHtml = await detail.Content.ReadAsStringAsync();
+        var detailDoc = await _context.OpenAsync(req => req.Content(detailHtml));
+        Assert.Contains(link.Text, detailDoc.QuerySelectorAll("h1").Last().TextContent);
+    }
+}

--- a/MiniBBS.Tests/UserServiceTests.cs
+++ b/MiniBBS.Tests/UserServiceTests.cs
@@ -1,0 +1,86 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using MiniBBS.DB;
+using MiniBBS.Service;
+using Moq;
+
+namespace MiniBBS.Tests;
+
+public class UserServiceTests
+{
+    private ForumDbContext GetContext()
+    {
+        var options = new DbContextOptionsBuilder<ForumDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        return new ForumDbContext(options);
+    }
+
+    private static UserManager<User> CreateUserManager(ForumDbContext context)
+    {
+        var store = new UserStore<User, IdentityRole<int>, ForumDbContext, int>(context);
+        var options = new Mock<IOptions<IdentityOptions>>();
+        options.Setup(o => o.Value).Returns(new IdentityOptions());
+        var userManager = new UserManager<User>(store, options.Object, new PasswordHasher<User>(),
+            [new UserValidator<User>()], [new PasswordValidator<User>()], new UpperInvariantLookupNormalizer(),
+            new IdentityErrorDescriber(), null!, new Mock<ILogger<UserManager<User>>>().Object);
+        return userManager;
+    }
+
+    private static SignInManager<User> CreateSignInManager(UserManager<User> userManager)
+    {
+        var contextAccessor = new Mock<IHttpContextAccessor>();
+        var claimsFactory = new Mock<IUserClaimsPrincipalFactory<User>>();
+        var options = new Mock<IOptions<IdentityOptions>>();
+        options.Setup(o => o.Value).Returns(new IdentityOptions());
+        var logger = new Mock<ILogger<SignInManager<User>>>();
+        var schemes = new Mock<IAuthenticationSchemeProvider>();
+        var confirmation = new Mock<IUserConfirmation<User>>();
+        return new SignInManager<User>(userManager, contextAccessor.Object, claimsFactory.Object,
+            options.Object, logger.Object, schemes.Object, confirmation.Object);
+    }
+
+    [Fact]
+    public async Task CanCreateUpdateAndDeleteUser()
+    {
+        using var context = GetContext();
+        var userManager = CreateUserManager(context);
+        var signInManager = CreateSignInManager(userManager);
+        var service = new UserService(userManager, signInManager);
+
+        var user = new User { UserName = "u" };
+        var created = await service.CreateUserAsync(user);
+        Assert.NotNull(created);
+
+        user.UserName = "new";
+        var updated = await service.UpdateUserAsync(user);
+        Assert.Equal("new", updated?.UserName);
+
+        var deleted = await service.DeleteUserAsync(user.Id);
+        Assert.True(deleted);
+    }
+
+    [Fact]
+    public async Task ValidateUser_ReturnsTrue()
+    {
+        var userStore = new Mock<IUserStore<User>>();
+        var userManager = new Mock<UserManager<User>>(userStore.Object, null!, null!, null!, null!, null!, null!, null!, null!);
+        userManager.Setup(m => m.FindByNameAsync("u")).ReturnsAsync(new User());
+
+        var signInManagerMock = new Mock<SignInManager<User>>(userManager.Object, new Mock<IHttpContextAccessor>().Object,
+            new Mock<IUserClaimsPrincipalFactory<User>>().Object, new Mock<IOptions<IdentityOptions>>().Object,
+            new Mock<ILogger<SignInManager<User>>>().Object, new Mock<IAuthenticationSchemeProvider>().Object,
+            new Mock<IUserConfirmation<User>>().Object);
+        signInManagerMock.Setup(s => s.CheckPasswordSignInAsync(It.IsAny<User>(), "p", false))
+            .ReturnsAsync(SignInResult.Success);
+
+        var service = new UserService(userManager.Object, signInManagerMock.Object);
+        var result = await service.ValidateUserAsync("u", "p");
+        Assert.True(result);
+    }
+}

--- a/MiniBBS/Program.cs
+++ b/MiniBBS/Program.cs
@@ -70,3 +70,5 @@ app.MapControllerRoute(
     pattern: "{controller=Home}/{action=Index}/{id?}");
 
 app.Run();
+
+public partial class Program { }


### PR DESCRIPTION
## Summary
- expand service tests to cover update and delete logic
- add UserService tests with mocked identity components
- add UI integration test simulating navigation using AngleSharp
- configure test host with custom WebApplicationFactory
- expose Program class for WebApplicationFactory

## Testing
- `dotnet test -v q`

------
https://chatgpt.com/codex/tasks/task_e_6843300f46348327b959102595a62bef