### PR TITLE
Add post and forum admin management

### DIFF
--- a/MiniBBS.Tests/AdminControllerTests.cs
+++ b/MiniBBS.Tests/AdminControllerTests.cs
@@ -44,4 +44,32 @@ public class AdminControllerTests
         var model = Assert.IsAssignableFrom<IEnumerable<AdminUserViewModel>>(result?.Model);
         Assert.Single(model);
     }
+
+    [Fact]
+    public async Task Forums_ReturnsViewWithModel()
+    {
+        using var context = GetContext();
+        context.Forums.Add(new Forum { ForumName = "F", Description = "D" });
+        context.SaveChanges();
+        var controller = new AdminController(context, CreateUserManager(context));
+
+        var result = await controller.Forums() as ViewResult;
+        var model = Assert.IsAssignableFrom<IEnumerable<AdminForumViewModel>>(result?.Model);
+        Assert.Single(model);
+    }
+
+    [Fact]
+    public async Task Posts_ReturnsViewWithModel()
+    {
+        using var context = GetContext();
+        context.Users.Add(new User { Id = 1, UserName = "u" });
+        context.Forums.Add(new Forum { ForumID = 1, ForumName = "F", Description = "D" });
+        context.Posts.Add(new Post { Title = "t", Content = "c", ForumID = 1, UserID = 1, PostedTime = DateTime.UtcNow });
+        context.SaveChanges();
+        var controller = new AdminController(context, CreateUserManager(context));
+
+        var result = await controller.Posts() as ViewResult;
+        var model = Assert.IsAssignableFrom<IEnumerable<AdminPostViewModel>>(result?.Model);
+        Assert.Single(model);
+    }
 }

--- a/MiniBBS/Controllers/AdminController.cs
+++ b/MiniBBS/Controllers/AdminController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using MiniBBS.DB;
 using MiniBBS.Models;
 using System.Collections.Generic;
@@ -62,6 +63,70 @@ namespace MiniBBS.Controllers
                 await _userManager.DeleteAsync(user);
             }
             return RedirectToAction(nameof(Users));
+        }
+
+        public async Task<IActionResult> Forums()
+        {
+            var forums = await _context.Forums.ToListAsync();
+            var model = forums.Select(f => new AdminForumViewModel
+            {
+                ForumId = f.ForumID,
+                ForumName = f.ForumName,
+                Description = f.Description ?? string.Empty
+            });
+            return View(model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> CreateForum(string forumName, string description)
+        {
+            if (!string.IsNullOrWhiteSpace(forumName))
+            {
+                _context.Forums.Add(new Forum { ForumName = forumName, Description = description ?? string.Empty });
+                await _context.SaveChangesAsync();
+            }
+            return RedirectToAction(nameof(Forums));
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteForum(int id)
+        {
+            var forum = await _context.Forums.FindAsync(id);
+            if (forum != null)
+            {
+                _context.Forums.Remove(forum);
+                await _context.SaveChangesAsync();
+            }
+            return RedirectToAction(nameof(Forums));
+        }
+
+        public async Task<IActionResult> Posts()
+        {
+            var posts = await _context.Posts.Include(p => p.User).Include(p => p.Forum).ToListAsync();
+            var model = posts.Select(p => new AdminPostViewModel
+            {
+                PostId = p.PostID,
+                Title = p.Title,
+                ForumName = p.Forum?.ForumName ?? string.Empty,
+                Username = p.User?.UserName ?? string.Empty,
+                PostedTime = p.PostedTime
+            }).ToList();
+            return View(model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeletePost(int id)
+        {
+            var post = await _context.Posts.FindAsync(id);
+            if (post != null)
+            {
+                _context.Posts.Remove(post);
+                await _context.SaveChangesAsync();
+            }
+            return RedirectToAction(nameof(Posts));
         }
     }
 }

--- a/MiniBBS/Models/AdminForumViewModel.cs
+++ b/MiniBBS/Models/AdminForumViewModel.cs
@@ -1,0 +1,9 @@
+namespace MiniBBS.Models
+{
+    public class AdminForumViewModel
+    {
+        public int ForumId { get; set; }
+        public string ForumName { get; set; }
+        public string Description { get; set; }
+    }
+}

--- a/MiniBBS/Models/AdminPostViewModel.cs
+++ b/MiniBBS/Models/AdminPostViewModel.cs
@@ -1,0 +1,11 @@
+namespace MiniBBS.Models
+{
+    public class AdminPostViewModel
+    {
+        public int PostId { get; set; }
+        public string Title { get; set; }
+        public string ForumName { get; set; }
+        public string Username { get; set; }
+        public DateTime PostedTime { get; set; }
+    }
+}

--- a/MiniBBS/Views/Admin/Forums.cshtml
+++ b/MiniBBS/Views/Admin/Forums.cshtml
@@ -1,0 +1,49 @@
+@model IEnumerable<MiniBBS.Models.AdminForumViewModel>
+@{
+    ViewData["Title"] = "Forum Management";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <title>@ViewData["Title"] - MiniBBS</title>
+</head>
+<body>
+    <div class="container mt-4">
+        <h1>Forum Management</h1>
+        <form asp-action="CreateForum" method="post" class="form-inline mb-3">
+            <input type="text" name="forumName" class="form-control mr-2" placeholder="Name" required />
+            <input type="text" name="description" class="form-control mr-2" placeholder="Description" />
+            <button type="submit" class="btn btn-success">Add</button>
+        </form>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Name</th>
+                    <th>Description</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var forum in Model)
+                {
+                    <tr>
+                        <td>@forum.ForumId</td>
+                        <td>@forum.ForumName</td>
+                        <td>@forum.Description</td>
+                        <td>
+                            <form asp-action="DeleteForum" method="post" class="d-inline">
+                                <input type="hidden" name="id" value="@forum.ForumId" />
+                                <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this forum?');">Delete</button>
+                            </form>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+        <a class="btn btn-secondary" href="@Url.Action("Index", "Admin")">Back</a>
+    </div>
+</body>
+</html>

--- a/MiniBBS/Views/Admin/Index.cshtml
+++ b/MiniBBS/Views/Admin/Index.cshtml
@@ -19,6 +19,8 @@
             <li class="list-group-item">Comments: @Model.CommentCount</li>
         </ul>
         <a class="btn btn-primary mt-3" href="@Url.Action("Users", "Admin")">Manage Users</a>
+        <a class="btn btn-primary mt-3" href="@Url.Action("Forums", "Admin")">Manage Forums</a>
+        <a class="btn btn-primary mt-3" href="@Url.Action("Posts", "Admin")">Manage Posts</a>
     </div>
 </body>
 </html>

--- a/MiniBBS/Views/Admin/Posts.cshtml
+++ b/MiniBBS/Views/Admin/Posts.cshtml
@@ -1,0 +1,48 @@
+@model IEnumerable<MiniBBS.Models.AdminPostViewModel>
+@{
+    ViewData["Title"] = "Post Management";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <title>@ViewData["Title"] - MiniBBS</title>
+</head>
+<body>
+    <div class="container mt-4">
+        <h1>Post Management</h1>
+        <table class="table table-striped mt-3">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Title</th>
+                    <th>Forum</th>
+                    <th>User</th>
+                    <th>Posted</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var post in Model)
+                {
+                    <tr>
+                        <td>@post.PostId</td>
+                        <td>@post.Title</td>
+                        <td>@post.ForumName</td>
+                        <td>@post.Username</td>
+                        <td>@post.PostedTime.ToString("yyyy-MM-dd")</td>
+                        <td>
+                            <form asp-action="DeletePost" method="post" class="d-inline">
+                                <input type="hidden" name="id" value="@post.PostId" />
+                                <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this post?');">Delete</button>
+                            </form>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+        <a class="btn btn-secondary" href="@Url.Action("Index", "Admin")">Back</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement admin pages to manage forums and posts
- expose new actions in `AdminController`
- create `AdminForumViewModel` and `AdminPostViewModel`
- add views for post and forum management
- update dashboard with links
- cover new features with tests

## Testing
- `dotnet test --no-restore --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68433c5de0908327acdc0de34d256998