### PR TITLE
Add admin comment management

### DIFF
--- a/MiniBBS.Tests/AdminControllerTests.cs
+++ b/MiniBBS.Tests/AdminControllerTests.cs
@@ -144,4 +144,35 @@ public class AdminControllerTests
         await controller.EditPost(new AdminPostFormViewModel { PostId = post.PostID, Title = "n", Content = "n", ForumId = 1, UserId = 1 });
         Assert.Equal("n", context.Posts.First().Title);
     }
+
+    [Fact]
+    public async Task PostComments_ReturnsViewWithModel()
+    {
+        using var context = GetContext();
+        context.Users.Add(new User { Id = 1, UserName = "u" });
+        context.Forums.Add(new Forum { ForumID = 1, ForumName = "F", Description = "d" });
+        context.Posts.Add(new Post { PostID = 1, Title = "t", Content = "c", ForumID = 1, UserID = 1, PostedTime = DateTime.UtcNow });
+        context.Comments.Add(new Comment { CommentID = 1, Content = "cc", PostID = 1, UserID = 1, PostedTime = DateTime.UtcNow });
+        context.SaveChanges();
+        var controller = new AdminController(context, CreateUserManager(context));
+
+        var result = await controller.PostComments(1) as ViewResult;
+        var model = Assert.IsAssignableFrom<IEnumerable<AdminCommentViewModel>>(result?.Model);
+        Assert.Single(model);
+    }
+
+    [Fact]
+    public async Task DeleteComment_RemovesComment()
+    {
+        using var context = GetContext();
+        context.Users.Add(new User { Id = 1, UserName = "u" });
+        context.Forums.Add(new Forum { ForumID = 1, ForumName = "F", Description = "d" });
+        context.Posts.Add(new Post { PostID = 1, Title = "t", Content = "c", ForumID = 1, UserID = 1, PostedTime = DateTime.UtcNow });
+        context.Comments.Add(new Comment { CommentID = 1, Content = "cc", PostID = 1, UserID = 1, PostedTime = DateTime.UtcNow });
+        context.SaveChanges();
+        var controller = new AdminController(context, CreateUserManager(context));
+
+        await controller.DeleteComment(1, 1);
+        Assert.Empty(context.Comments);
+    }
 }

--- a/MiniBBS/Controllers/AdminController.cs
+++ b/MiniBBS/Controllers/AdminController.cs
@@ -286,5 +286,37 @@ namespace MiniBBS.Controllers
             }
             return RedirectToAction(nameof(Posts));
         }
+
+        public async Task<IActionResult> PostComments(int postId)
+        {
+            SetNavBar();
+            ViewBag.PostId = postId;
+            var comments = await _context.Comments
+                .Where(c => c.PostID == postId)
+                .Include(c => c.User)
+                .ToListAsync();
+
+            var model = comments.Select(c => new AdminCommentViewModel
+            {
+                CommentId = c.CommentID,
+                Content = c.Content,
+                Username = c.User?.UserName ?? string.Empty,
+                PostedTime = c.PostedTime
+            });
+            return View("Comments", model);
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> DeleteComment(int id, int postId)
+        {
+            var comment = await _context.Comments.FindAsync(id);
+            if (comment != null)
+            {
+                _context.Comments.Remove(comment);
+                await _context.SaveChangesAsync();
+            }
+            return RedirectToAction(nameof(PostComments), new { postId });
+        }
     }
 }

--- a/MiniBBS/Models/AdminCommentViewModel.cs
+++ b/MiniBBS/Models/AdminCommentViewModel.cs
@@ -1,0 +1,10 @@
+namespace MiniBBS.Models
+{
+    public class AdminCommentViewModel
+    {
+        public int CommentId { get; set; }
+        public string Content { get; set; }
+        public string Username { get; set; }
+        public DateTime PostedTime { get; set; }
+    }
+}

--- a/MiniBBS/Views/Admin/Comments.cshtml
+++ b/MiniBBS/Views/Admin/Comments.cshtml
@@ -1,0 +1,47 @@
+@model IEnumerable<MiniBBS.Models.AdminCommentViewModel>
+@{
+    ViewData["Title"] = "Comment Management";
+}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <title>@ViewData["Title"] - MiniBBS</title>
+</head>
+<body>
+    <div class="container mt-4">
+        <h1>Comment Management</h1>
+        <table class="table table-striped mt-3">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Content</th>
+                    <th>User</th>
+                    <th>Posted</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var c in Model)
+                {
+                    <tr>
+                        <td>@c.CommentId</td>
+                        <td>@c.Content</td>
+                        <td>@c.Username</td>
+                        <td>@c.PostedTime.ToString("yyyy-MM-dd")</td>
+                        <td>
+                            <form asp-action="DeleteComment" method="post" class="d-inline">
+                                <input type="hidden" name="id" value="@c.CommentId" />
+                                <input type="hidden" name="postId" value="@ViewBag.PostId" />
+                                <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this comment?');">Delete</button>
+                            </form>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+        <a class="btn btn-secondary" href="@Url.Action("Posts", "Admin")">Back</a>
+    </div>
+</body>
+</html>

--- a/MiniBBS/Views/Admin/Posts.cshtml
+++ b/MiniBBS/Views/Admin/Posts.cshtml
@@ -23,6 +23,7 @@
                     <th>User</th>
                     <th>Posted</th>
                     <th></th>
+                    <th>Comments</th>
                 </tr>
             </thead>
             <tbody>
@@ -40,6 +41,9 @@
                                 <input type="hidden" name="id" value="@post.PostId" />
                                 <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this post?');">Delete</button>
                             </form>
+                        </td>
+                        <td>
+                            <a class="btn btn-sm btn-info" href="@Url.Action("PostComments", "Admin", new { postId = post.PostId })">Comments</a>
                         </td>
                     </tr>
                 }


### PR DESCRIPTION
## Summary
- add `AdminCommentViewModel`
- implement comment management actions in `AdminController`
- add admin Comments view
- link comment management from Posts view
- cover comment management with new tests

## Testing
- `dotnet restore`
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6844829235648327a61f14ee345686d5